### PR TITLE
Improvements to RangerIter

### DIFF
--- a/cidranger.go
+++ b/cidranger.go
@@ -271,8 +271,13 @@ func getRollupEntries(trie *prefixTrie, f RollupApply) []RangerEntry {
 		// If both have an entry, check to rollup
 		if node.children[0].hasEntry() && node.children[1].hasEntry() {
 			if f.CanRollup(node.children[0].entry, node.children[1].entry) {
-				rollupEntries = append(rollupEntries,
-					f.GetParentEntry(node.children[0].entry, node.children[1].entry, node.network.IPNet),
+				rollupEntries = append(
+					rollupEntries,
+					f.GetParentEntry(
+						node.children[0].entry,
+						node.children[1].entry,
+						node.network.IPNet,
+					),
 				)
 			}
 			continue

--- a/cidranger.go
+++ b/cidranger.go
@@ -150,6 +150,7 @@ func Subnets(base net.IPNet, prefixlen int) (subnets []net.IPNet, err error) {
 type RangerIter interface {
 	Next() bool
 	Get() RangerEntry
+	GetPath() []RangerEntry
 	Error() error
 }
 
@@ -204,6 +205,16 @@ func (i *bredthRangerIter) Next() bool {
 
 func (i *bredthRangerIter) Get() RangerEntry {
 	return i.node.entry
+}
+
+func (i *bredthRangerIter) GetPath() []RangerEntry {
+	retv := make([]RangerEntry, 0)
+	for this := i.node; this.parent != nil; this = this.parent {
+		if this.hasEntry() {
+			retv = append(retv, this.entry)
+		}
+	}
+	return retv
 }
 
 func (i *bredthRangerIter) Error() error {

--- a/cidranger.go
+++ b/cidranger.go
@@ -142,7 +142,7 @@ func Subnets(base net.IPNet, prefixlen int) (subnets []net.IPNet, err error) {
 }
 
 // RangerIter is an interface to use with an iterator-like pattern
-// ri := NewBredthIter(ptrie)
+// ri := NewBreadthIter(ptrie)
 // for ri.Next() {
 //     entry := ri.Get()
 //     ...
@@ -220,13 +220,13 @@ func (i *versionedRangerIter) GetPath() []RangerEntry {
 	return i.v4.GetPath()
 }
 
-// A bredth-first iterator that returns all netblocks with a RangerEntry
-func NewBredthIter(r Ranger) *rangerIter {
+// A breadth-first iterator that returns all netblocks with a RangerEntry
+func NewBreadthIter(r Ranger) *rangerIter {
 	return NewIter(r, false, TraversalMethodBreadth)
 }
 
-// A bredth-first iterator that will return only the largest netblocks with an entry
-func NewShallowBredthIter(r Ranger) *rangerIter {
+// A breadth-first iterator that will return only the largest netblocks with an entry
+func NewShallowBreadthIter(r Ranger) *rangerIter {
 	return NewIter(r, true, TraversalMethodBreadth)
 }
 

--- a/cidranger_test.go
+++ b/cidranger_test.go
@@ -162,7 +162,7 @@ func TestSubnets(t *testing.T) {
 	}
 }
 
-func TestBredthRangerIter(t *testing.T) {
+func TestBreadthRangerIter(t *testing.T) {
 	cases := []struct {
 		version  rnet.IPVersion
 		inserts  []string
@@ -192,7 +192,7 @@ func TestBredthRangerIter(t *testing.T) {
 				expectedEntries = append(expectedEntries, (*network))
 			}
 			var resultEntries []net.IPNet
-			iter := NewBredthIter(trie.(*prefixTrie))
+			iter := NewBreadthIter(trie.(*prefixTrie))
 			for iter.Next() {
 				entry := iter.Get()
 				resultEntries = append(resultEntries, entry.Network())
@@ -350,7 +350,7 @@ func TestRollupApply(t *testing.T) {
 				assert.Errorf(t, err, "Expected error: %v", tc.err)
 			}
 			if tc.err == nil && err == nil {
-				iter := NewShallowBredthIter(trie.(*prefixTrie))
+				iter := NewShallowBreadthIter(trie.(*prefixTrie))
 				for iter.Next() {
 					entry := iter.Get()
 					resultEntries = append(resultEntries, entry.(RecordEntry))

--- a/cidranger_test.go
+++ b/cidranger_test.go
@@ -129,7 +129,13 @@ func TestSubnets(t *testing.T) {
 		name     string
 	}{
 		{"0.0.0.0/8", 33, nil, rnet.ErrBadMaskLength, "IPv4 prefix too long"},
-		{"0.0.0.0/0", 2, []string{"0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"}, nil, "IPv4 /0 to /2"},
+		{
+			"0.0.0.0/0",
+			2,
+			[]string{"0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"},
+			nil,
+			"IPv4 /0 to /2",
+		},
 		{"10.0.0.0/8", 0, []string{"10.0.0.0/9", "10.128.0.0/9"}, nil, "IPv4 default split /8"},
 		{"::/2", 4, []string{"::/4", "1000::/4", "2000::/4", "3000::/4"}, nil, "IPv6 /2 to /4"},
 		{"10.0.0.0/15", 15, []string{"10.0.0.0/15"}, nil, "IPv4 prefix self"},
@@ -165,7 +171,12 @@ func TestBredthRangerIter(t *testing.T) {
 	}{
 		{rnet.IPv4, []string{}, []string{}, "empty"},
 		{rnet.IPv4, []string{"1.2.3.4/15"}, []string{"1.2.3.4/15"}, "single v4"},
-		{rnet.IPv4, []string{"255.0.0.0/8", "0.0.0.0/8"}, []string{"0.0.0.0/8", "255.0.0.0/8"}, "ordering v4"},
+		{
+			rnet.IPv4,
+			[]string{"255.0.0.0/8", "0.0.0.0/8"},
+			[]string{"0.0.0.0/8", "255.0.0.0/8"},
+			"ordering v4",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -218,7 +229,11 @@ func (rc rollupCount) CanRollup(c0 RangerEntry, c1 RangerEntry) bool {
 	return rc0.Records+rc1.Records < rc.rollupThreshold
 }
 
-func (rc rollupCount) GetParentEntry(c0 RangerEntry, c1 RangerEntry, parentNet net.IPNet) RangerEntry {
+func (rc rollupCount) GetParentEntry(
+	c0 RangerEntry,
+	c1 RangerEntry,
+	parentNet net.IPNet,
+) RangerEntry {
 	rc0, ok := c0.(RecordEntry)
 	if !ok {
 		panic(c0)
@@ -332,10 +347,18 @@ func BenchmarkBruteRangerHitContainingNetworksIPv4UsingAWSRanges(b *testing.B) {
 }
 
 func BenchmarkPCTrieHitContainingNetworksIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620:107:300f::36b7:ff81"), NewPCTrieRanger())
+	benchmarkContainingNetworksUsingAWSRanges(
+		b,
+		net.ParseIP("2620:107:300f::36b7:ff81"),
+		NewPCTrieRanger(),
+	)
 }
 func BenchmarkBruteRangerHitContainingNetworksIPv6UsingAWSRanges(b *testing.B) {
-	benchmarkContainingNetworksUsingAWSRanges(b, net.ParseIP("2620:107:300f::36b7:ff81"), newBruteRanger())
+	benchmarkContainingNetworksUsingAWSRanges(
+		b,
+		net.ParseIP("2620:107:300f::36b7:ff81"),
+		newBruteRanger(),
+	)
 }
 
 func BenchmarkPCTrieMissContainingNetworksIPv4UsingAWSRanges(b *testing.B) {

--- a/trie_test.go
+++ b/trie_test.go
@@ -79,7 +79,12 @@ func TestPrefixTrieInsert(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			assert.Equal(t, len(tc.expectedNetworksInDepthOrder), trie.Len(), "trie size should match")
+			assert.Equal(
+				t,
+				len(tc.expectedNetworksInDepthOrder),
+				trie.Len(),
+				"trie size should match",
+			)
 
 			allNetworks, err := trie.CoveredNetworks(*getAllByVersion(tc.version))
 			assert.Nil(t, err)
@@ -213,7 +218,12 @@ func TestPrefixTrieRemove(t *testing.T) {
 				}
 			}
 
-			assert.Equal(t, len(tc.expectedNetworksInDepthOrder), trie.Len(), "trie size should match after revmoval")
+			assert.Equal(
+				t,
+				len(tc.expectedNetworksInDepthOrder),
+				trie.Len(),
+				"trie size should match after revmoval",
+			)
 
 			allNetworks, err := trie.CoveredNetworks(*getAllByVersion(tc.version))
 			assert.Nil(t, err)
@@ -686,7 +696,11 @@ func TestTrieMemUsage(t *testing.T) {
 
 	// Assert that heap allocation from first loop is within set threshold of avg over all runs.
 	assert.Less(t, uint64(0), baseLineHeap)
-	assert.LessOrEqual(t, float64(baseLineHeap), float64(totalHeapAllocOverRuns/uint64(runs))*thresh)
+	assert.LessOrEqual(
+		t,
+		float64(baseLineHeap),
+		float64(totalHeapAllocOverRuns/uint64(runs))*thresh,
+	)
 }
 
 func GenLeafIPNet(ip net.IP) net.IPNet {


### PR DESCRIPTION
- Add depth-first traversal
- Add support for mixed IPv4 and IPv6
- Add a `GetPath` method to `RangeIter` which returns all entries on the path from root to the current node (what `Get` returns)